### PR TITLE
New Intent Tests and Misc Fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -29,7 +29,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityAddProblemIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityAddProblemIntentTest.java
@@ -38,5 +38,8 @@ public class ActivityAddProblemIntentTest {
         Problem pr = ProblemRecordListController.getProblemList().getArray().get(0);
         assertTrue(pr.getTitle().equals(testProblemTitle));
         assertTrue(pr.getDescription().equals(testProblemDesc));
+
+        ProblemRecordListController.getProblemList().remove(pr,
+                intentsTestRule.getActivity().getBaseContext());
     }
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityAddRecordIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityAddRecordIntentTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.support.test.espresso.intent.matcher.IntentMatchers;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,6 +24,8 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ActivityAddRecordIntentTest {
+
+    private Problem pr;
 
     @Rule
     public IntentsTestRule<ActivityAddRecord> intentsTestRule =
@@ -56,5 +59,10 @@ public class ActivityAddRecordIntentTest {
         Record r = ProblemRecordListController.getRecordList().getArray().get(0);
         assertTrue(r.getTitle().equals(testRecordTitle));
         assertTrue(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @After
+    public void after() {
+        ProblemRecordListController.getProblemList().remove_internal(pr);
     }
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityAddRecordIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityAddRecordIntentTest.java
@@ -35,7 +35,7 @@ public class ActivityAddRecordIntentTest {
     // create mock intent with mock patient and mock problem
     public void before() {
         Patient p = new Patient("Patty2222", "testPatient@example.com", "555-123-4567", "Patient");
-        Problem pr = new Problem("Possible concussion", LocalDateTime.now(),
+        pr = new Problem("Possible concussion", LocalDateTime.now(),
                 "From car accident", p.getElasticID());
         ProblemRecordListController.getProblemList().add_internal(pr);
 

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityBrowseProblemsIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityBrowseProblemsIntentTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.anything;
 
 public class ActivityBrowseProblemsIntentTest {
 
+    private Patient p;
     private Problem pr;
 
     @Rule
@@ -29,7 +30,7 @@ public class ActivityBrowseProblemsIntentTest {
     @Before
     // create mock patient with mock problem
     public void setup() {
-        Patient p = new Patient("Patty2222", "testpatient@example.com", "555-123-4567", "Patient");
+        p = new Patient("Patty2222", "testpatient@example.com", "555-123-4567", "Patient");
         pr = new Problem("Ear Infection", LocalDateTime.now(), "Right ear", p.getElasticID());
         p.getProblems().add(pr.getElasticID());
 
@@ -71,8 +72,8 @@ public class ActivityBrowseProblemsIntentTest {
 
     @After
     public void after() {
-        ProblemRecordListController.getProblemList().remove(pr,
-                intentsTestRule.getActivity().getBaseContext());
+        UserListController.getUserList().remove_internal(p);
+        ProblemRecordListController.getProblemList().remove_internal(pr);
     }
 
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityBrowseProblemsIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityBrowseProblemsIntentTest.java
@@ -71,7 +71,8 @@ public class ActivityBrowseProblemsIntentTest {
 
     @After
     public void after() {
-        ProblemRecordListController.getProblemList().remove(pr);
+        ProblemRecordListController.getProblemList().remove(pr,
+                intentsTestRule.getActivity().getBaseContext());
     }
 
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityCareGiverAddPatientIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityCareGiverAddPatientIntentTest.java
@@ -1,0 +1,73 @@
+package com.example.loggerdoc;
+
+import android.content.Intent;
+import android.support.test.espresso.intent.rule.IntentsTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.example.loggerdoc.IntentTestUtils.waitForUserListUpdate;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+public class ActivityCareGiverAddPatientIntentTest {
+
+    private CareGiver c;
+    private Patient p;
+
+    @Rule
+    public IntentsTestRule<ActivityCareGiverAddPatient> intentsTestRule =
+            new IntentsTestRule<>(ActivityCareGiverAddPatient.class, false, false);
+
+    @Before
+    public void before() {
+        c = new CareGiver("DoctorJim", "testcaregiver@example.com", "555-555-1234", "Caregiver");
+        p = new Patient("NotADoctor", "testpatient@example.com", "555-123-4567", "Patient");
+
+        UserListController.getUserList().add_internal(c);
+        UserListController.getUserList().add_internal(p);
+
+        Intent i = new Intent();
+        i.putExtra("Caregiver", c.getElasticID());
+        intentsTestRule.launchActivity(i);
+    }
+
+    @Test
+    public void TestAddPatientToCaregiver() {
+        String testPatientName = "NotADoctor";
+
+        onView(withId(R.id.AddPatientEditText))
+                .perform(typeText(testPatientName), closeSoftKeyboard());
+        onView(withId(R.id.AddPatientButton))
+                .perform(click());
+
+        assertTrue(c.getPatientList().contains(p.getElasticID()));
+        assertTrue(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @Test
+    public void TestAddNonExistentPatient() {
+        String testPatientName = "NotARealUser26277";
+
+        onView(withId(R.id.AddPatientEditText))
+                .perform(typeText(testPatientName), closeSoftKeyboard());
+        onView(withId(R.id.AddPatientButton))
+                .perform(click());
+
+        assertFalse(c.getPatientList().contains(p.getElasticID()));
+        assertFalse(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @After
+    public void after() {
+        UserListController.getUserList().remove_internal(c);
+        UserListController.getUserList().remove_internal(p);
+    }
+}

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityCareGiverBrowsePatientsIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityCareGiverBrowsePatientsIntentTest.java
@@ -3,6 +3,7 @@ package com.example.loggerdoc;
 import android.content.Intent;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,6 +18,9 @@ import static org.hamcrest.CoreMatchers.anything;
 
 public class ActivityCareGiverBrowsePatientsIntentTest {
 
+    private CareGiver c;
+    private Patient p;
+
     @Rule
     public IntentsTestRule<ActivityCareGiverBrowsePatients> intentsTestRule =
             new IntentsTestRule<>(ActivityCareGiverBrowsePatients.class, false, false);
@@ -24,8 +28,8 @@ public class ActivityCareGiverBrowsePatientsIntentTest {
     @Before
     // create mock caregiver with mock patient
     public void setup() {
-        CareGiver c = new CareGiver("CareBear", "testcaregiver@example.com", "555-555-1234", "Caregiver");
-        Patient p = new Patient("Patty2222", "testpatient@example.com", "555-123-4567", "Patient");
+        c = new CareGiver("CareBear", "testcaregiver@example.com", "555-555-1234", "Caregiver");
+        p = new Patient("Patty2222", "testpatient@example.com", "555-123-4567", "Patient");
         c.addPatient(p);
 
         UserListController.getUserList().add_internal(c);
@@ -48,5 +52,11 @@ public class ActivityCareGiverBrowsePatientsIntentTest {
         onView(withId(R.id.addPatientButton))
                 .perform(click());
         intended(hasComponent(ActivityCareGiverAddPatient.class.getName()));
+    }
+
+    @After
+    public void after() {
+        UserListController.getUserList().remove_internal(c);
+        UserListController.getUserList().remove_internal(p);
     }
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityCareGiverHomePageIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityCareGiverHomePageIntentTest.java
@@ -3,6 +3,7 @@ package com.example.loggerdoc;
 import android.content.Intent;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,6 +16,8 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 public class ActivityCareGiverHomePageIntentTest {
 
+    private CareGiver c;
+
     @Rule
     public IntentsTestRule<ActivityCareGiverHomePage> intentsTestRule =
             new IntentsTestRule<>(ActivityCareGiverHomePage.class, false, false);
@@ -22,7 +25,7 @@ public class ActivityCareGiverHomePageIntentTest {
     @Before
     // create mock caregiver
     public void setup() {
-        CareGiver c = new CareGiver("CareBear", "testcaregiver@example.com", "555-555-1234", "Caregiver");
+        c = new CareGiver("CareBear", "testcaregiver@example.com", "555-555-1234", "Caregiver");
         UserListController.getUserList().add_internal(c);
 
         Intent i = new Intent();
@@ -42,5 +45,10 @@ public class ActivityCareGiverHomePageIntentTest {
         onView(withId(R.id.browse_patients_button2))
                 .perform(click());
         intended(hasComponent(ActivityCareGiverBrowsePatients.class.getName()));
+    }
+
+    @After
+    public void after() {
+        UserListController.getUserList().remove_internal(c);
     }
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityLoginIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityLoginIntentTest.java
@@ -14,6 +14,7 @@ import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.intent.Intents.intended;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.example.loggerdoc.IntentTestUtils.waitForUserListUpdate;
 
 public class ActivityLoginIntentTest {
 
@@ -24,12 +25,7 @@ public class ActivityLoginIntentTest {
     @Before
     public void before() {
         intentsTestRule.launchActivity(new Intent());
-        try {
-            Thread.sleep(500); // a delay to ensure that new accounts get properly loaded
-        }
-        catch (InterruptedException e) {
-            // never
-        }
+        waitForUserListUpdate();
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityLoginIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityLoginIntentTest.java
@@ -38,6 +38,8 @@ public class ActivityLoginIntentTest {
         onView(withId(R.id.Login_Button))
                 .perform(click());
         intended(hasComponent(ActivityPatientHomePage.class.getName()));
+
+        UserListController.getUserList().remove_internal(p);
     }
 
     @Test
@@ -50,5 +52,7 @@ public class ActivityLoginIntentTest {
         onView(withId(R.id.Login_Button))
                 .perform(click());
         intended(hasComponent(ActivityCareGiverHomePage.class.getName()));
+
+        UserListController.getUserList().remove_internal(c);
     }
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityPatientHomePageIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityPatientHomePageIntentTest.java
@@ -3,6 +3,7 @@ package com.example.loggerdoc;
 import android.content.Intent;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,6 +16,8 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 public class ActivityPatientHomePageIntentTest {
 
+    private Patient p;
+
     @Rule
     public IntentsTestRule<ActivityPatientHomePage> intentsTestRule =
             new IntentsTestRule<>(ActivityPatientHomePage.class, false, false);
@@ -22,7 +25,7 @@ public class ActivityPatientHomePageIntentTest {
     @Before
     // create mock patient
     public void setup() {
-        Patient p = new Patient("Patty2222", "testpatient@example.com", "555-123-4567", "Patient");
+        p = new Patient("Patty2222", "testpatient@example.com", "555-123-4567", "Patient");
         UserListController.getUserList().add_internal(p);
 
         Intent i = new Intent();
@@ -42,5 +45,10 @@ public class ActivityPatientHomePageIntentTest {
         onView(withId(R.id.browse_problems_button))
                 .perform(click());
         intended(hasComponent(ActivityBrowseProblems.class.getName()));
+    }
+
+    @After
+    public void after() {
+        UserListController.getUserList().remove_internal(p);
     }
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityUpdateContactInfoIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityUpdateContactInfoIntentTest.java
@@ -1,0 +1,132 @@
+package com.example.loggerdoc;
+
+import android.content.Intent;
+import android.support.test.espresso.intent.rule.IntentsTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.clearText;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.intent.Intents.intended;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static junit.framework.Assert.assertTrue;
+
+public class ActivityUpdateContactInfoIntentTest {
+
+    private CareGiver c;
+    private Patient p;
+
+    private String careGiverName = "DoctorJim";
+    private String careGiverEmail = "testcaregiver@example.com";
+    private String careGiverPhone = "555-555-1234";
+    private String patientName = "TimothyPleb";
+    private String patientEmail = "testpatient@example.com";
+    private String patientPhone = "555-123-4567";
+
+    private String newEmail = "newEmail@example.com";
+    private String newPhone = "403-991-4924";
+
+
+    @Rule
+    public IntentsTestRule<ActivityUpdateContactInfo> intentsTestRule =
+            new IntentsTestRule<>(ActivityUpdateContactInfo.class, false, false);
+
+    @Before
+    public void before() {
+        c = new CareGiver(careGiverName, careGiverEmail, careGiverPhone, "Caregiver");
+        p = new Patient(patientName, patientEmail, patientPhone, "Patient");
+
+        UserListController.getUserList().add_internal(c);
+        UserListController.getUserList().add_internal(p);
+    }
+
+    @Test
+    public void TestEditEmailAsCareGiver() {
+        Intent i = new Intent();
+        i.putExtra("Caregiver", c.getElasticID());
+        intentsTestRule.launchActivity(i);
+
+        onView(withId(R.id.UserNameDisplay))
+                .check(matches(withText(careGiverName)));
+        onView(withId(R.id.edit_contact_info_email_view))
+                .check(matches(withText(careGiverEmail)));
+        onView(withId(R.id.edit_contact_info_number_view))
+                .check(matches(withText(careGiverPhone)));
+
+        onView(withId(R.id.edit_contact_info_email_view))
+                .perform(clearText(), typeText(newEmail), closeSoftKeyboard());
+
+        onView(withId(R.id.updateContactInfoSaveButton))
+                .perform(click());
+
+        assertTrue(c.getEmailAddress().equals(newEmail));
+        assertTrue(c.getPhoneNumber().equals(careGiverPhone));
+        assertTrue(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @Test
+    public void TestEditEmailAndPhoneAsPatient() {
+        Intent i = new Intent();
+        i.putExtra("Patient", p.getElasticID());
+        intentsTestRule.launchActivity(i);
+
+        onView(withId(R.id.UserNameDisplay))
+                .check(matches(withText(patientName)));
+        onView(withId(R.id.edit_contact_info_email_view))
+                .check(matches(withText(patientEmail)));
+        onView(withId(R.id.edit_contact_info_number_view))
+                .check(matches(withText(patientPhone)));
+
+        onView(withId(R.id.edit_contact_info_email_view))
+                .perform(clearText(), typeText(newEmail), closeSoftKeyboard());
+        onView(withId(R.id.edit_contact_info_number_view))
+                .perform(clearText(), typeText(newPhone), closeSoftKeyboard());
+
+        onView(withId(R.id.updateContactInfoSaveButton))
+                .perform(click());
+
+        assertTrue(p.getEmailAddress().equals(newEmail));
+        assertTrue(p.getPhoneNumber().equals(newPhone));
+        assertTrue(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @Test
+    public void TestEditEmailAndCancelAsPatient() {
+        Intent i = new Intent();
+        i.putExtra("Patient", p.getElasticID());
+        intentsTestRule.launchActivity(i);
+
+        onView(withId(R.id.UserNameDisplay))
+                .check(matches(withText(patientName)));
+        onView(withId(R.id.edit_contact_info_email_view))
+                .check(matches(withText(patientEmail)));
+        onView(withId(R.id.edit_contact_info_number_view))
+                .check(matches(withText(patientPhone)));
+
+        onView(withId(R.id.edit_contact_info_email_view))
+                .perform(clearText(), typeText(newEmail), closeSoftKeyboard());
+
+        onView(withId(R.id.UpdateContactInfoCancelButton))
+                .perform(click());
+
+        assertTrue(p.getEmailAddress().equals(patientEmail));
+        assertTrue(p.getPhoneNumber().equals(patientPhone));
+        assertTrue(intentsTestRule.getActivity().isFinishing());
+
+    }
+
+    @After
+    public void after() {
+        UserListController.getUserList().remove_internal(c);
+        UserListController.getUserList().remove_internal(p);
+    }
+}

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityUserProfileIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityUserProfileIntentTest.java
@@ -1,0 +1,99 @@
+package com.example.loggerdoc;
+
+import android.content.Intent;
+import android.support.test.espresso.intent.rule.IntentsTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.intent.Intents.intended;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static junit.framework.Assert.assertTrue;
+
+public class ActivityUserProfileIntentTest {
+
+    private CareGiver c;
+    private Patient p;
+
+    private String careGiverName = "DoctorJim";
+    private String careGiverEmail = "testcaregiver@example.com";
+    private String careGiverPhone = "555-555-1234";
+    private String patientName = "TimothyPleb";
+    private String patientEmail = "testpatient@example.com";
+    private String patientPhone = "555-123-4567";
+
+
+    @Rule
+    public IntentsTestRule<ActivityUserProfile> intentsTestRule =
+            new IntentsTestRule<>(ActivityUserProfile.class, false, false);
+
+    @Before
+    public void before() {
+        c = new CareGiver(careGiverName, careGiverEmail, careGiverPhone, "Caregiver");
+        p = new Patient(patientName, patientEmail, patientPhone, "Patient");
+
+        UserListController.getUserList().add_internal(c);
+        UserListController.getUserList().add_internal(p);
+    }
+
+    @Test
+    public void TestUserProfileAsCareGiver() {
+        Intent i = new Intent();
+        i.putExtra("Caregiver", c.getElasticID());
+        intentsTestRule.launchActivity(i);
+
+        onView(withId(R.id.UserNameDisplay))
+                .check(matches(withText(careGiverName)));
+        onView(withId(R.id.edit_contact_info_email_view))
+                .check(matches(withText(careGiverEmail)));
+        onView(withId(R.id.edit_contact_info_number_view))
+                .check(matches(withText(careGiverPhone)));
+        onView(withId(R.id.backButton))
+                .perform(click());
+
+        assertTrue(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @Test
+    public void TestUserProfileAsPatient() {
+        Intent i = new Intent();
+        i.putExtra("Patient", p.getElasticID());
+        intentsTestRule.launchActivity(i);
+
+        onView(withId(R.id.UserNameDisplay))
+                .check(matches(withText(patientName)));
+        onView(withId(R.id.edit_contact_info_email_view))
+                .check(matches(withText(patientEmail)));
+        onView(withId(R.id.edit_contact_info_number_view))
+                .check(matches(withText(patientPhone)));
+        onView(withId(R.id.backButton))
+                .perform(click());
+
+        assertTrue(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @Test
+    public void TestEditProfileFromProfile() {
+        Intent i = new Intent();
+        i.putExtra("Patient", p.getElasticID());
+        intentsTestRule.launchActivity(i);
+
+        onView(withId(R.id.EditContactInfoButton))
+                .perform(click());
+        intended(hasComponent(ActivityUpdateContactInfo.class.getName()));
+    }
+
+    @After
+    public void after() {
+        UserListController.getUserList().remove_internal(c);
+        UserListController.getUserList().remove_internal(p);
+    }
+}

--- a/app/src/androidTest/java/com/example/loggerdoc/ActivityViewProblemIntentTest.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/ActivityViewProblemIntentTest.java
@@ -3,6 +3,7 @@ package com.example.loggerdoc;
 import android.content.Intent;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,5 +63,10 @@ public class ActivityViewProblemIntentTest {
                 .perform(click());
         assertFalse(ProblemRecordListController.getProblemList().contains(pr));
         assertTrue(intentsTestRule.getActivity().isFinishing());
+    }
+
+    @After
+    public void after() {
+        ProblemRecordListController.getProblemList().remove_internal(pr);
     }
 }

--- a/app/src/androidTest/java/com/example/loggerdoc/IntentTestUtils.java
+++ b/app/src/androidTest/java/com/example/loggerdoc/IntentTestUtils.java
@@ -1,0 +1,13 @@
+package com.example.loggerdoc;
+
+public class IntentTestUtils {
+
+    public static void waitForUserListUpdate() {
+        try {
+            Thread.sleep(500); // a delay to ensure that new accounts get properly loaded
+        }
+        catch (InterruptedException e) {
+            // never
+        }
+    }
+}

--- a/app/src/main/java/com/example/loggerdoc/ActivityCareGiverAddPatient.java
+++ b/app/src/main/java/com/example/loggerdoc/ActivityCareGiverAddPatient.java
@@ -57,15 +57,13 @@ public class ActivityCareGiverAddPatient extends AppCompatActivity {
                 UserListController.getUserList().add(loggedInCareGiver,getApplicationContext());
                 userID.setText("");
                 finish();
+                return;
             }
-            else{
-                Toast.makeText(this, "That username does not exist. Please try again.", Toast.LENGTH_SHORT).show();
-                userID.setText("");
-
-            }
-
-
         }
+
+        // otherwise, if the provided user isn't in the list:
+        Toast.makeText(this, "That username does not exist. Please try again.", Toast.LENGTH_SHORT).show();
+        userID.setText("");
     }
 
 

--- a/app/src/main/java/com/example/loggerdoc/ActivityUpdateContactInfo.java
+++ b/app/src/main/java/com/example/loggerdoc/ActivityUpdateContactInfo.java
@@ -35,7 +35,7 @@ public class ActivityUpdateContactInfo extends AppCompatActivity {
         phoneNumberEditText = (EditText) findViewById(R.id.edit_contact_info_number_view);
         contactInfoEmailWarning = (ImageView) findViewById(R.id.warningEditEmail);
         contactInfoPhoneWarning = (ImageView) findViewById(R.id.warningEditPhoneNumber);
-        userId = (TextView) findViewById(R.id.ProblemTitle);
+        userId = (TextView) findViewById(R.id.UserNameDisplay);
 
 
         //get the logged in user from the intent

--- a/app/src/main/java/com/example/loggerdoc/ActivityUserProfile.java
+++ b/app/src/main/java/com/example/loggerdoc/ActivityUserProfile.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -30,7 +29,7 @@ public class ActivityUserProfile extends AppCompatActivity {
         //initialize all of the views
         emailEditText = (TextView) findViewById(R.id.edit_contact_info_email_view);
         phoneNumberEditText = (TextView) findViewById(R.id.edit_contact_info_number_view);
-        userIdView = (TextView) findViewById(R.id.ProblemTitle);
+        userIdView = (TextView) findViewById(R.id.UserNameDisplay);
         qrCodeImageView = (ImageView) findViewById(R.id.QrCodeImageView);
 
         //get the user being viewed from the intent

--- a/app/src/main/java/com/example/loggerdoc/AdapterListProblems.java
+++ b/app/src/main/java/com/example/loggerdoc/AdapterListProblems.java
@@ -3,7 +3,6 @@ package com.example.loggerdoc;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,7 +37,7 @@ public class AdapterListProblems extends ArrayAdapter<Problem> {
         }
         Problem currentProblem = problemList.get(position);
 
-        TextView problemTitle = (TextView) listitem.findViewById(R.id.ProblemTitle);
+        TextView problemTitle = (TextView) listitem.findViewById(R.id.UserNameDisplay);
         problemTitle.setText(currentProblem.getTitle());
 
         TextView date = (TextView) listitem.findViewById(R.id.DateView);

--- a/app/src/main/res/layout/activity_update_contact_info.xml
+++ b/app/src/main/res/layout/activity_update_contact_info.xml
@@ -7,7 +7,7 @@
     tools:context=".ActivityUpdateContactInfo">
 
     <TextView
-        android:id="@+id/ProblemTitle"
+        android:id="@+id/UserNameDisplay"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
@@ -33,7 +33,7 @@
         android:text="@string/cancel_button"
         android:textColor="@android:color/white"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/ProblemTitle"
+        app:layout_constraintStart_toEndOf="@+id/UserNameDisplay"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
@@ -46,7 +46,7 @@
         android:onClick="saveChanges"
         android:text="@string/save_button"
         android:textColor="@android:color/white"
-        app:layout_constraintEnd_toStartOf="@+id/ProblemTitle"
+        app:layout_constraintEnd_toStartOf="@+id/UserNameDisplay"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -89,7 +89,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ProblemTitle">
+        app:layout_constraintTop_toBottomOf="@+id/UserNameDisplay">
 
         <TextView
             android:id="@+id/edit_contact_info_email_address"

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -7,7 +7,7 @@
     tools:context=".ActivityUserProfile">
 
     <TextView
-        android:id="@+id/ProblemTitle"
+        android:id="@+id/UserNameDisplay"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
@@ -33,7 +33,7 @@
         android:text="Edit Contact Info"
         android:textColor="@android:color/white"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/ProblemTitle"
+        app:layout_constraintStart_toEndOf="@+id/UserNameDisplay"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
@@ -46,7 +46,7 @@
         android:onClick="endActivity"
         android:text="Back"
         android:textColor="@android:color/background_light"
-        app:layout_constraintEnd_toStartOf="@+id/ProblemTitle"
+        app:layout_constraintEnd_toStartOf="@+id/UserNameDisplay"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -61,7 +61,7 @@
         android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ProblemTitle">
+        app:layout_constraintTop_toBottomOf="@+id/UserNameDisplay">
 
         <TextView
             android:id="@+id/edit_contact_info_email_address"

--- a/app/src/main/res/layout/activity_view_problem.xml
+++ b/app/src/main/res/layout/activity_view_problem.xml
@@ -33,7 +33,7 @@
         android:text="@string/delete_button"
         android:textColor="@android:color/white"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/ProblemTitle"
+        app:layout_constraintStart_toEndOf="@+id/UserNameDisplay"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
@@ -47,7 +47,7 @@
         android:onClick="goEditProblem"
         android:text="@string/edit_problem_button"
         android:textColor="@android:color/white"
-        app:layout_constraintEnd_toStartOf="@+id/ProblemTitle"
+        app:layout_constraintEnd_toStartOf="@+id/UserNameDisplay"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/browse_problem_list_view.xml
+++ b/app/src/main/res/layout/browse_problem_list_view.xml
@@ -11,7 +11,7 @@
         android:orientation="vertical">
 
         <TextView
-            android:id="@+id/ProblemTitle"
+            android:id="@+id/UserNameDisplay"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="TextView"


### PR DESCRIPTION
* Fixed a relatively serious issue with ActivityCareGiverAddPatient where it would say the patient didn't exist if it wasn't the first patient in the userlist
* 3 new intent tests for:
    * ActivityCareGiverAddPatient
    * ActivityUserProfile
    * ActivityUpdateContactInfo
* Miscellaneous fixes to prevent spamming Elasticsearch server